### PR TITLE
Fix slow intro animation blocking Torgnole express questions

### DIFF
--- a/jeu du duc.html
+++ b/jeu du duc.html
@@ -198,7 +198,7 @@
     #setup{animation:introZoom 0.5s ease-out forwards;}
     @keyframes introZoom{from{transform:scale(1.5);}to{transform:scale(1);}}
     #effect-container{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;overflow:hidden;z-index:999;}
-    .effect{position:absolute;top:50%;left:50%;width:20px;height:20px;border-radius:50%;opacity:0.8;transform:translate(-50%,-50%);animation:moveEffect 30s linear forwards;}
+    .effect{position:absolute;top:50%;left:50%;width:20px;height:20px;border-radius:50%;opacity:0.8;transform:translate(-50%,-50%);animation:moveEffect 3s linear forwards;}
     .flame{background:radial-gradient(circle,var(--yellow),var(--orange-dark));}
     .spray{background:radial-gradient(circle,#a8e,#58f);}
     @keyframes moveEffect{to{transform:translate(calc(-50% + var(--x)),calc(-50% + var(--y))) scale(0);opacity:0;}}
@@ -308,7 +308,7 @@
             el.style.setProperty("--y",Math.sin(angle)*dist+"px");
             container.appendChild(el);
           }
-          setTimeout(()=>{container.remove();resolve();},30000);
+          setTimeout(()=>{container.remove();resolve();},3000);
         });
       }
 


### PR DESCRIPTION
## Summary
- Shorten intro particle animation from 30s to 3s
- Resolve long wait before questions appear in hardcore and Torgnole express modes

## Testing
- `node -e "const fs=require('fs');const content=fs.readFileSync('jeu du duc.html','utf8');const script=content.match(/<script>([\s\S]*)<\/script>/)[1];new Function(script);console.log('syntax ok');"`


------
https://chatgpt.com/codex/tasks/task_e_68b1b5e9113483288ea77c4e856b79d0