### PR TITLE
Corrige Time's Up

### DIFF
--- a/jeu du duc.html
+++ b/jeu du duc.html
@@ -306,6 +306,24 @@
   margin: 1rem;
 }
 
+/* BEGIN timeup-buttons-style */
+#timeup-round-buttons {
+  display: flex;
+  justify-content: space-around;
+  margin-top: 1rem;
+}
+#timeup-valid-btn {
+  background: #4caf50;
+}
+#timeup-pass-btn {
+  background: #f44336;
+}
+#timeup-round-buttons button {
+  flex: 1;
+  margin: 0 1rem;
+}
+/* END timeup-buttons-style */
+
   </style>
 </head>
 <body>
@@ -478,8 +496,12 @@
       <p id="timeup-turn-info"></p>
       <div id="timeup-timer">30</div>
       <div id="timeup-card-display"></div>
-      <button id="timeup-valid-btn">Validé</button>
-      <button id="timeup-pass-btn">Passer</button>
+      <!-- BEGIN timeup-round-buttons -->
+      <div id="timeup-round-buttons">
+        <button id="timeup-valid-btn">Validé</button>
+        <button id="timeup-pass-btn">Passer</button>
+      </div>
+      <!-- END timeup-round-buttons -->
     </div>
     <div id="timeup-round-end" class="timeup-section timeup-hidden">
       <h2>Fin de manche</h2>
@@ -4453,6 +4475,10 @@ const TIMEUP_DEFAULT_CARDS = [
   // BEGIN timeup-card-db
   ,'Sauterelle','Parapluie','Kangourou','Tournesol','Dauphin'
   ,'Boussole','Glacier','Volcan','Viking','Zèbre'
+  ,'chat','voiture','fromage','Emmanuel Macron','maison','ordinateur','pomme'
+  ,'tour Eiffel','pizza','bouteille','cigarette','football','Paris','chien'
+  ,'avion','café','plage','chocolat','smartphone','montagne','stylo','guitare'
+  ,'dragon','sushi','bibliothèque','soleil','lune','banane','volcan'
   // END timeup-card-db
 ];
 
@@ -4746,6 +4772,10 @@ if(timeupBtn){
         timeupScreen.classList.add('timeup-hidden');
         setupScreen.classList.remove('hidden');
         document.body.style.background='linear-gradient(135deg,#ff7a18,#ffcc00)';
+        // BEGIN timeup-reset-on-exit
+        localStorage.removeItem('timeup.state');
+        timeupState={stage:'setup',players:[],cards:[],round:1,deck:[],currentPlayer:0,currentCard:null,scores:{},startTeam:1};
+        // END timeup-reset-on-exit
       });
 
       timeupRender();


### PR DESCRIPTION
## Summary
- Ajout d'une base de cartes par défaut pour Time's Up
- Mise en forme des boutons de manche avec couleurs et espacement
- Réinitialisation complète du jeu Time's Up lors du retour à l'accueil

## Testing
- `npm test` *(échoue: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b215eb348328a139ad5c36c27c8b