### PR TITLE
Hide Undercover setup after game start

### DIFF
--- a/jeu du duc.html
+++ b/jeu du duc.html
@@ -105,7 +105,7 @@
 }
 
 .hidden {
-  display: none;
+  display: none !important;
 }
 
 .result-screen {


### PR DESCRIPTION
## Summary
- Ensure `.hidden` class forces display none so Undercover config disappears once game begins

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca5afa948328b1bf88a78e3e0586