### PR TITLE
Ensure custom sliders fill card width

### DIFF
--- a/jeu du duc.html
+++ b/jeu du duc.html
@@ -214,7 +214,12 @@
       font-size: 0.9rem;
       margin-bottom: 0.3rem;
     }
-    .slider-container input { width: 100%; }
+    /* // BEGIN slider-fullwidth */
+    .slider-container input {
+      width: 100%;
+      max-width: 100%;
+    }
+    /* // END slider-fullwidth */
 
     @media (max-width: 600px) {
       .question { font-size: 1.1rem; min-height: 100px; }


### PR DESCRIPTION
## Summary
- allow custom mode sliders to expand across the full width of their container

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b592fbf6b88328aec3e886452cb827