### PR TITLE
Remove animations when launching game screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,9 @@
       flex-direction: column;
       justify-content: center;
       align-items: center;
-      transition: background 0.6s;
+      /* // BEGIN no-bg-transition */
+      /* transition: background 0.6s; */
+      /* // END no-bg-transition */
       background: linear-gradient(135deg,var(--orange),var(--yellow));
     }
 
@@ -470,22 +472,9 @@
       }
       
       function playIntroAnimation(mode){
-        return new Promise(resolve=>{
-          const container=document.createElement("div");
-          container.id="effect-container";
-          document.body.appendChild(container);
-          const count=30;
-          for(let i=0;i<count;i++){
-            const el=document.createElement("div");
-            el.className="effect "+(mode==="hardcore"?"flame":"spray");
-            const angle=Math.random()*Math.PI*2;
-            const dist=300+Math.random()*200;
-            el.style.setProperty("--x",Math.cos(angle)*dist+"px");
-            el.style.setProperty("--y",Math.sin(angle)*dist+"px");
-            container.appendChild(el);
-          }
-          setTimeout(()=>{container.remove();resolve();},3000);
-        });
+        // BEGIN skip-intro-animation
+        return Promise.resolve();
+        // END skip-intro-animation
       }
 
     function pickCustomMode(){const total=weights.debut+weights.hardcore+weights.alcool+weights.culture;let r=Math.random()*total;if(r<weights.debut)return"debut";r-=weights.debut;if(r<weights.hardcore)return"hardcore";r-=weights.hardcore;if(r<weights.alcool)return"alcool";return"culture";}


### PR DESCRIPTION
## Summary
- Remove background transition to display game screens instantly
- Skip intro animation for hardcore and alcool modes so games open immediately

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5decb6a108328a5734fa5965f59d1