### PR TITLE
feat: block start without players

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,6 +460,9 @@
     }
 
     async function startGame(){
+        // BEGIN start-game-player-check
+        if(players.length<1){alert("Ajoute au moins 1 joueur !");return;}
+        // END start-game-player-check
         if(currentMode!=="culture"&&players.length<2&&currentMode!=="custom"){alert("Ajoute au moins 2 joueurs !");return;}
         if(currentMode==="hardcore"||currentMode==="alcool"){
           await playIntroAnimation(currentMode);


### PR DESCRIPTION
## Summary
- ensure at least one player is entered before starting any game mode

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dfec59c483288bc339d63b7519b7