### PR TITLE
feat: add alcohol toggle for culture mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,6 +290,18 @@
     #killer-secret.killer-hidden{display:none;}
     /* END killer-secret-hide */
 
+    /* // BEGIN culture-alcool-style */
+    .toggle-container{display:flex;align-items:center;justify-content:center;gap:0.5rem;margin-bottom:0.5rem;}
+    .switch{position:relative;display:inline-block;width:50px;height:24px;}
+    .switch input{opacity:0;width:0;height:0;}
+    .slider{position:absolute;cursor:pointer;top:0;left:0;right:0;bottom:0;background:#ccc;transition:.4s;border-radius:24px;}
+    .slider:before{position:absolute;content:"";height:20px;width:20px;left:2px;bottom:2px;background:white;transition:.4s;border-radius:50%;}
+    .switch input:checked+.slider{background:var(--yellow);}
+    .switch input:checked+.slider:before{transform:translateX(26px);}
+    .toggle-label{font-size:0.9rem;}
+    #gorgeesText{font-weight:bold;}
+    /* // END culture-alcool-style */
+
   </style>
 </head>
 <body>
@@ -340,8 +352,20 @@
 
   <div id="game" class="card hidden">
     <img src="icon.png" alt="Logo Jeu du Duc" id="backLogo" class="logo">
+    <!-- // BEGIN culture-alcool-toggle -->
+    <div id="cultureToggleContainer" class="toggle-container hidden">
+      <label class="switch">
+        <input type="checkbox" id="cultureToggle">
+        <span class="slider"></span>
+      </label>
+      <span class="toggle-label">Mode Alcool</span>
+    </div>
+    <!-- // END culture-alcool-toggle -->
     <div id="typeBox" class="question-type"></div>
     <p class="question" id="currentQuestion"></p>
+    <!-- // BEGIN culture-gorgees-display -->
+    <p id="gorgeesText" class="hidden"></p>
+    <!-- // END culture-gorgees-display -->
     <div id="answerBox">
       <button id="showAnswerBtn">Voir la réponse</button>
       <p id="answerText"></p>
@@ -445,6 +469,11 @@
     // -------------------------
     const setupScreen=document.getElementById("setup"),gameScreen=document.getElementById("game"),playerInput=document.getElementById("playerInput"),playerList=document.getElementById("playerList"),currentQuestionEl=document.getElementById("currentQuestion"),typeBox=document.getElementById("typeBox"),answerBox=document.getElementById("answerBox"),showAnswerBtn=document.getElementById("showAnswerBtn"),answerText=document.getElementById("answerText"),backLogo=document.getElementById("backLogo"),customWeightsBox=document.getElementById("customWeights"),undercoverScreen=document.getElementById("undercover"),backUndercover=document.getElementById("backUndercover"),undercoverTitle=document.getElementById("undercoverTitle");
     const sliders={debut:document.getElementById("weight-debut"),hardcore:document.getElementById("weight-hardcore"),alcool:document.getElementById("weight-alcool"),culture:document.getElementById("weight-culture")};
+    // BEGIN culture-toggle-setup
+    const cultureToggleContainer=document.getElementById("cultureToggleContainer"),cultureToggle=document.getElementById("cultureToggle"),gorgeesText=document.getElementById("gorgeesText");
+    let cultureDrinkMode=false;
+    if(cultureToggle){cultureToggle.addEventListener("change",()=>{cultureDrinkMode=cultureToggle.checked;});}
+    // END culture-toggle-setup
 
     function addPlayer(){const name=playerInput.value.trim();if(name&&players.length<30){players.push(name);renderPlayerList();playerInput.value="";playerInput.focus();}}
     function removePlayer(i){players.splice(i,1);renderPlayerList();}
@@ -483,11 +512,13 @@
     function pickCustomMode(){const total=weights.debut+weights.hardcore+weights.alcool+weights.culture;let r=Math.random()*total;if(r<weights.debut)return"debut";r-=weights.debut;if(r<weights.hardcore)return"hardcore";r-=weights.hardcore;if(r<weights.alcool)return"alcool";return"culture";}
 
     function showQuestion(){currentQuestionEl.textContent="";typeBox.textContent="";answerBox.style.display="none";answerText.textContent="";rapidityMode=false;
+      if(cultureToggleContainer)cultureToggleContainer.classList.add("hidden");
+      if(gorgeesText)gorgeesText.classList.add("hidden");
       let mode=currentMode;if(mode==="custom")mode=pickCustomMode();
       const rapidityMap={debut:0.08,hardcore:0.04,alcool:0.08,culture:0.02};
       const rapidityChance=rapidityMap[mode]||0;
       if(Math.random()<rapidityChance){rapidityMode=true;typeBox.textContent="RAPIDITÉ";setBackground("RAPIDITÉ");currentQuestionEl.textContent="⚡ Question de rapidité pour tout le monde ! (Cliquez pour révéler)";return;}
-      if(mode==="culture"){const q=cultureQuestions[Math.floor(Math.random()*cultureQuestions.length)];const player=players[Math.floor(Math.random()*players.length)];typeBox.textContent="CULTURE G.";setBackground("CULTURE G.");currentQuestionEl.textContent=`${player}, ${q.question}`;showAnswerBtn.style.display="inline-block";answerBox.style.display="block";showAnswerBtn.onclick=e=>{e.stopPropagation();answerText.textContent="✅ Réponse : "+q.answer;showAnswerBtn.style.display="none";};}
+      if(mode==="culture"){const q=cultureQuestions[Math.floor(Math.random()*cultureQuestions.length)];const player=players[Math.floor(Math.random()*players.length)];typeBox.textContent="CULTURE G.";setBackground("CULTURE G.");currentQuestionEl.textContent=`${player}, ${q.question}`;showAnswerBtn.style.display="inline-block";answerBox.style.display="block";showAnswerBtn.onclick=e=>{e.stopPropagation();answerText.textContent="✅ Réponse : "+q.answer;showAnswerBtn.style.display="none";};if(cultureToggleContainer)cultureToggleContainer.classList.remove("hidden");if(cultureDrinkMode&&gorgeesText){const g=Math.floor(Math.random()*3)+1;gorgeesText.textContent=`${g} gorgée${g>1?'s':''}`;gorgeesText.classList.remove("hidden");}}
       else if(mode==="debut"||mode==="hardcore"||mode==="alcool"){const pool={debut:debutQuestions,hardcore:hardcoreQuestions,alcool:alcoolQuestions}[mode];const [type,text]=pool[Math.floor(Math.random()*pool.length)].split("|");let player=players[Math.floor(Math.random()*players.length)];let qText=text.replace(/\{player\}/g,player);if(qText.includes("{other}")){let other;do{other=players[Math.floor(Math.random()*players.length)];}while(other===player&&players.length>1);qText=qText.replace(/\{other\}/g,other);}typeBox.textContent=type;setBackground(type);currentQuestionEl.textContent=qText;}}
     
     function nextQuestion(e){if(e.target.id==="showAnswerBtn")return;if(e.clientX>window.innerWidth/2){if(rapidityMode&&currentQuestionEl.textContent.includes("⚡")){const q=rapidityQuestions[Math.floor(Math.random()*rapidityQuestions.length)];currentQuestionEl.textContent=q;// BEGIN rapidity-question-fix


### PR DESCRIPTION
## Summary
- add toggle for optional alcohol mode in culture questions
- style new switch and display random gorgées
- wire culture mode to show random drinks when toggle enabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b71434f4348328b25155f0976db608