### PR TITLE
Reduce rapidity question rate

### DIFF
--- a/index.html
+++ b/index.html
@@ -732,6 +732,9 @@ const sliders={debut:document.getElementById("weight-debut"),hardcore:document.g
       if(gorgeesText)gorgeesText.classList.add("hidden");
       let mode=currentMode;if(mode==="custom")mode=pickCustomMode();
       const rapidityMap={debut:0.08,hardcore:0.04,alcool:0.08,culture:0.02};
+      // BEGIN reduce-rapidity-chance
+      if(rapidityMap){Object.assign(rapidityMap,{debut:0.02,hardcore:0.02,alcool:0.02,culture:0.02});}
+      // END reduce-rapidity-chance
       const rapidityChance=rapidityMap[mode]||0;
       if(Math.random()<rapidityChance){rapidityMode=true;typeBox.textContent="RAPIDITÉ";setBackground("RAPIDITÉ");currentQuestionEl.textContent="⚡ Question de rapidité pour tout le monde ! (Cliquez pour révéler)";
       // BEGIN rapidite-jingle


### PR DESCRIPTION
## Summary
- Limit rapidité question trigger chance to 2% across all game modes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b74a7e313c83289f80b1de7148e334