### PR TITLE
Fix MCQ rendering syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -817,13 +817,13 @@ const sliders={debut:document.getElementById("weight-debut"),hardcore:document.g
       qObj.choices.forEach((label, idx) => {
         const btn = document.createElement("button");
         btn.className = "mcq-btn";
- btn.addEventListener("click", event => {
+        // BEGIN mcq-btn-setup-fix
+        btn.textContent = label;
+        btn.addEventListener("click", event => {
           // BEGIN mcq-btn-priority-click
           event.stopPropagation();
           // END mcq-btn-priority-click
-          // Disable all
           [...mcqGrid.querySelectorAll("button")].forEach(b => b.disabled = true);
-          // Coloration
           if (idx === qObj.answerIndex) {
             btn.classList.add("mcq-correct");
           } else {
@@ -831,16 +831,7 @@ const sliders={debut:document.getElementById("weight-debut"),hardcore:document.g
             mcqGrid.children[qObj.answerIndex].classList.add("mcq-correct");
           }
         }, { once:true });
-          // Disable all
-          [...mcqGrid.querySelectorAll("button")].forEach(b => b.disabled = true);
-          // Coloration
-          if (idx === qObj.answerIndex) {
-            btn.classList.add("mcq-correct");
-          } else {
-            btn.classList.add("mcq-wrong");
-            mcqGrid.children[qObj.answerIndex].classList.add("mcq-correct");
-          }
-        }, { once:true });
+        // END mcq-btn-setup-fix
         mcqGrid.appendChild(btn);
       });
     }


### PR DESCRIPTION
## Summary
- correct the MCQ button creation logic so each choice renders its label and registers a single click handler

## Testing
- node -e "const fs=require('fs');const html=fs.readFileSync('index.html','utf8');const parts=html.split('<script>');parts.slice(1).forEach((part,i)=>{const code=part.split('</script>')[0];new Function(code);});"


------
https://chatgpt.com/codex/tasks/task_e_68cadbd2b5fc8328aa2a8e79a99b341e