### PR TITLE
Add redirect entry point for renamed HTML page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Jeu du Duc – redirection</title>
+  <meta http-equiv="refresh" content="0; url=indexsept.html">
+  <link rel="canonical" href="indexsept.html">
+  <script>
+    (function() {
+      var target = 'indexsept.html';
+      var search = window.location.search || '';
+      var hash = window.location.hash || '';
+      window.location.replace(target + search + hash);
+    })();
+  </script>
+</head>
+<body>
+  <p>Si vous n'êtes pas redirigé automatiquement, <a href="indexsept.html">cliquez ici pour accéder au Jeu du Duc</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a lightweight index.html that redirects to the new indexsept.html entry point
- preserve query strings and hash fragments when redirecting
- provide a manual link fallback when automatic redirect is unavailable

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd34fb2f408328a67272dcf5ddf1fb