### PR TITLE
Désactiver la rapidité en mode Culture G

### DIFF
--- a/scripts/app/main-game.js
+++ b/scripts/app/main-game.js
@@ -217,7 +217,7 @@
       debut: 0.02,
       hardcore: 0.02,
       alcool: 0.02,
-      culture: 0.02,
+      culture: 0,
     };
 
     const rapidityChance = rapidityChanceMap[mode] || 0;


### PR DESCRIPTION
## Summary
- supprimer la probabilité de déclencher le mode rapidité lorsque le mode Culture G est sélectionné

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd9bb6cd248328ac093127a7bf873f